### PR TITLE
Upgrade to Python 3

### DIFF
--- a/scripts/mididump
+++ b/scripts/mididump
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import midi
 import sys

--- a/scripts/mididump
+++ b/scripts/mididump
@@ -5,7 +5,7 @@ import sys
 import pickle
 
 if len(sys.argv) != 2:
-    print "Usage: {0} <midifile>".format(sys.argv[0])
+    print("Usage: {0} <midifile>".format(sys.argv[0]))
     sys.exit(2)
 
 midifile = sys.argv[1]
@@ -21,6 +21,6 @@ for track in pattern:
             idx = event.pitch / 12
             histogram[idx] += 1
 
-    print histogram
+    print(histogram)
 
-print repr(pattern)
+print(repr(pattern))

--- a/scripts/mididumphw
+++ b/scripts/mididumphw
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import midi.sequencer as sequencer
 

--- a/scripts/mididumphw
+++ b/scripts/mididumphw
@@ -4,4 +4,4 @@ import midi.sequencer as sequencer
 
 s = sequencer.SequencerHardware()
 
-print s
+print(s)

--- a/scripts/midilisten
+++ b/scripts/midilisten
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import time

--- a/scripts/midilisten
+++ b/scripts/midilisten
@@ -6,7 +6,7 @@ import midi
 import midi.sequencer as sequencer
 
 if len(sys.argv) != 3:
-    print "Usage: {0} <client> <port>".format(sys.argv[0])
+    print("Usage: {0} <client> <port>".format(sys.argv[0]))
     exit(2)
 
 client = sys.argv[1]
@@ -19,4 +19,4 @@ seq.start_sequencer()
 while True:
   event = seq.event_read()
   if event is not None:
-      print event
+      print(event)

--- a/scripts/midiplay
+++ b/scripts/midiplay
@@ -6,7 +6,7 @@ import midi
 import midi.sequencer as sequencer
 
 if len(sys.argv) != 4:
-    print "Usage: {0} <client> <port> <file>".format(sys.argv[0])
+    print("Usage: {0} <client> <port> <file>".format(sys.argv[0]))
     exit(2)
 
 client   = sys.argv[1]
@@ -41,4 +41,4 @@ for event in events:
         time.sleep(.5)
 time.sleep(30)
 
-print 'The end?'
+print('The end?')

--- a/scripts/midiplay
+++ b/scripts/midiplay
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import time

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from distutils.core import setup, Extension
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def configure_platform():
         setup_alsa(ns)
         pass
     else:
-        print "No sequencer available for '%s' platform." % platform
+        print("No sequencer available for '%s' platform." % platform)
     return ns
 
 setup(**configure_platform())

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,6 @@
-from containers import *
-from events import *
+from .containers import *
+from .events import *
+from .util import *
+from .fileio import *
+
 from struct import unpack, pack
-from util import *
-from fileio import *

--- a/src/constants.py
+++ b/src/constants.py
@@ -3,23 +3,23 @@
 ##
 
 OCTAVE_MAX_VALUE = 12
-OCTAVE_VALUES = range( OCTAVE_MAX_VALUE )
+OCTAVE_VALUES = list(range(OCTAVE_MAX_VALUE))
 
 NOTE_NAMES = ['C','Cs','D','Ds','E','F','Fs','G','Gs','A','As','B']
 WHITE_KEYS = [0, 2, 4, 5, 7, 9, 11]
 BLACK_KEYS = [1, 3, 6, 8, 10]
-NOTE_PER_OCTAVE = len( NOTE_NAMES )
-NOTE_VALUES = range( OCTAVE_MAX_VALUE * NOTE_PER_OCTAVE )
+NOTE_PER_OCTAVE = len(NOTE_NAMES)
+NOTE_VALUES = list(range(OCTAVE_MAX_VALUE * NOTE_PER_OCTAVE))
 NOTE_NAME_MAP_FLAT = {}
 NOTE_VALUE_MAP_FLAT = []
 NOTE_NAME_MAP_SHARP = {}
 NOTE_VALUE_MAP_SHARP = []
 
-for value in range( 128 ):
+for value in range(128):
     noteidx = value % NOTE_PER_OCTAVE
     octidx = value / OCTAVE_MAX_VALUE
     name = NOTE_NAMES[noteidx]
-    if len( name ) == 2:
+    if len(name) == 2:
         # sharp note
         flat = NOTE_NAMES[noteidx+1] + 'b'
         NOTE_NAME_MAP_FLAT['%s_%d' % (flat, octidx)] = value
@@ -46,4 +46,3 @@ THIRTYSECOND = 5
 SIXTYFOURTH = 6
 
 DEFAULT_MIDI_HEADER_SIZE = 14
-

--- a/src/events.py
+++ b/src/events.py
@@ -1,5 +1,5 @@
 import pdb
-class EventRegistry(object):
+class EventRegistry:
     Events = {}
     MetaEvents = {}
     
@@ -13,7 +13,7 @@ class EventRegistry(object):
                             "Event %s already registered" % event.name
             cls.Events[event.statusmsg] = event
         else:
-            raise ValueError, "Unknown bases class in event type: "+event.name
+            raise ValueError("Unknown bases class in event type: "+event.name)
     register_event = classmethod(register_event)
 
 
@@ -22,8 +22,7 @@ EventMIDI : Concrete class used to describe MIDI Events.
 Inherits from Event.
 """
 
-class AbstractEvent(object):
-    __slots__ = ['tick', 'data']
+class AbstractEvent:
     name = "Generic MIDI Event"
     length = 0
     statusmsg = 0x0
@@ -68,7 +67,6 @@ as the Meta  events.
 """
     
 class Event(AbstractEvent):
-    __slots__ = ['channel']
     name = 'Event'
 
     def __init__(self, **kw):
@@ -122,7 +120,6 @@ and NoteOff events.
 """
 
 class NoteEvent(Event):
-    __slots__ = ['pitch', 'velocity']
     length = 2
 
     def get_pitch(self):
@@ -151,7 +148,6 @@ class AfterTouchEvent(Event):
     name = 'After Touch'
 
 class ControlChangeEvent(Event):
-    __slots__ = ['control', 'value']
     statusmsg = 0xB0
     length = 2
     name = 'Control Change'
@@ -169,7 +165,6 @@ class ControlChangeEvent(Event):
     value = property(get_value, set_value)
     
 class ProgramChangeEvent(Event):
-    __slots__ = ['value']
     statusmsg = 0xC0
     length = 1
     name = 'Program Change'
@@ -181,7 +176,6 @@ class ProgramChangeEvent(Event):
     value = property(get_value, set_value)
 
 class ChannelAfterTouchEvent(Event):
-    __slots__ = ['value']
     statusmsg = 0xD0
     length = 1
     name = 'Channel After Touch'
@@ -193,7 +187,6 @@ class ChannelAfterTouchEvent(Event):
     value = property(get_value, set_value)
 
 class PitchWheelEvent(Event):
-    __slots__ = ['pitch']
     statusmsg = 0xE0
     length = 2
     name = 'Pitch Wheel'
@@ -277,7 +270,6 @@ class EndOfTrackEvent(MetaEvent):
     metacommand = 0x2F
 
 class SetTempoEvent(MetaEvent):
-    __slots__ = ['bpm', 'mpqn']
     name = 'Set Tempo'
     metacommand = 0x51
     length = 3
@@ -290,7 +282,7 @@ class SetTempoEvent(MetaEvent):
 
     def get_mpqn(self):
         assert(len(self.data) == 3)
-        vals = [self.data[x] << (16 - (8 * x)) for x in xrange(3)]
+        vals = [self.data[x] << (16 - (8 * x)) for x in range(3)]
         return sum(vals)
     def set_mpqn(self, val):
         self.data = [(val >> (16 - (8 * x)) & 0xFF) for x in range(3)]
@@ -301,7 +293,6 @@ class SmpteOffsetEvent(MetaEvent):
     metacommand = 0x54
 
 class TimeSignatureEvent(MetaEvent):
-    __slots__ = ['numerator', 'denominator', 'metronome', 'thirtyseconds']
     name = 'Time Signature'
     metacommand = 0x58
     length = 4

--- a/src/fileio.py
+++ b/src/fileio.py
@@ -1,21 +1,22 @@
-from containers import *
-from events import *
 from struct import unpack, pack
-from constants import *
-from util import *
 
-class FileReader(object):
+from .containers import *
+from .events import *
+from .constants import *
+from .util import *
+
+class FileReader:
     def read(self, midifile):
         pattern = self.parse_file_header(midifile)
         for track in pattern:
             self.parse_track(midifile, track)
         return pattern
-        
+
     def parse_file_header(self, midifile):
         # First four bytes are MIDI header
         magic = midifile.read(4)
         if magic != 'MThd':
-            raise TypeError, "Bad header in MIDI file."
+            raise TypeError("Bad header in MIDI file.")
         # next four bytes are header size
         # next two bytes specify the format version
         # next two bytes specify the number of tracks
@@ -31,12 +32,12 @@ class FileReader(object):
         if hdrsz > DEFAULT_MIDI_HEADER_SIZE:
             midifile.read(hdrsz - DEFAULT_MIDI_HEADER_SIZE)
         return Pattern(tracks=tracks, resolution=resolution, format=format)
-            
+
     def parse_track_header(self, midifile):
         # First four bytes are Track header
         magic = midifile.read(4)
         if magic != 'MTrk':
-            raise TypeError, "Bad track header in MIDI file: " + magic
+            raise TypeError("Bad track header in MIDI file: " + magic)
         # next four bytes are track size
         trksz = unpack(">L", midifile.read(4))[0]
         return trksz
@@ -56,21 +57,21 @@ class FileReader(object):
         # first datum is varlen representing delta-time
         tick = read_varlen(trackdata)
         # next byte is status message
-        stsmsg = ord(trackdata.next())
+        stsmsg = ord(next(trackdata))
         # is the event a MetaEvent?
         if MetaEvent.is_event(stsmsg):
-            cmd = ord(trackdata.next())
+            cmd = ord(next(trackdata))
             if cmd not in EventRegistry.MetaEvents:
-                raise Warning, "Unknown Meta MIDI Event: " + `cmd`
+                raise Warning("Unknown Meta MIDI Event: " + repr(cmd))
             cls = EventRegistry.MetaEvents[cmd]
             datalen = read_varlen(trackdata)
-            data = [ord(trackdata.next()) for x in range(datalen)]
+            data = [ord(next(trackdata)) for x in range(datalen)]
             return cls(tick=tick, data=data)
         # is this event a Sysex Event?
         elif SysexEvent.is_event(stsmsg):
             data = []
             while True:
-                datum = ord(trackdata.next())
+                datum = ord(next(trackdata))
                 if datum == 0xF7:
                     break
                 data.append(datum)
@@ -85,17 +86,17 @@ class FileReader(object):
                 cls = EventRegistry.Events[key]
                 channel = self.RunningStatus & 0x0F
                 data.append(stsmsg)
-                data += [ord(trackdata.next()) for x in range(cls.length - 1)]
+                data += [ord(next(trackdata)) for x in range(cls.length - 1)]
                 return cls(tick=tick, channel=channel, data=data)
             else:
                 self.RunningStatus = stsmsg
                 cls = EventRegistry.Events[key]
                 channel = self.RunningStatus & 0x0F
-                data = [ord(trackdata.next()) for x in range(cls.length)]
+                data = [ord(next(trackdata)) for x in range(cls.length)]
                 return cls(tick=tick, channel=channel, data=data)
-        raise Warning, "Unknown MIDI Event: " + `stsmsg`
+        raise Warning("Unknown MIDI Event: " + repr(stsmsg))
 
-class FileWriter(object):
+class FileWriter:
     def write(self, midifile, pattern):
         self.write_file_header(midifile, pattern)
         for track in pattern:
@@ -103,12 +104,12 @@ class FileWriter(object):
 
     def write_file_header(self, midifile, pattern):
         # First four bytes are MIDI header
-        packdata = pack(">LHHH", 6,    
-                            pattern.format, 
+        packdata = pack(">LHHH", 6,
+                            pattern.format,
                             len(pattern),
                             pattern.resolution)
         midifile.write('MThd%s' % packdata)
-            
+
     def write_track(self, midifile, track):
         buf = ''
         self.RunningStatus = None
@@ -127,11 +128,11 @@ class FileWriter(object):
         if isinstance(event, MetaEvent):
             ret += chr(event.statusmsg) + chr(event.metacommand)
             ret += write_varlen(len(event.data))
-            ret += str.join('', map(chr, event.data))
+            ret += str.join('', list(map(chr, event.data)))
         # is this event a Sysex Event?
         elif isinstance(event, SysexEvent):
             ret += chr(0xF0)
-            ret += str.join('', map(chr, event.data))
+            ret += str.join('', list(map(chr, event.data)))
             ret += chr(0xF7)
         # not a Meta MIDI event, must be a general message
         elif isinstance(event, Event):
@@ -140,19 +141,19 @@ class FileWriter(object):
                 self.RunningStatus.channel != event.channel:
                     self.RunningStatus = event
                     ret += chr(event.statusmsg | event.channel)
-            ret += str.join('', map(chr, event.data))
+            ret += str.join('', list(map(chr, event.data)))
         else:
-            raise ValueError, "Unknown MIDI Event: " + str(event)
+            raise ValueError("Unknown MIDI Event: " + str(event))
         return ret
 
 def write_midifile(midifile, pattern):
-    if type(midifile) in (str, unicode):
+    if type(midifile) in (str, str):
         midifile = open(midifile, 'wb')
     writer = FileWriter()
     return writer.write(midifile, pattern)
 
 def read_midifile(midifile):
-    if type(midifile) in (str, unicode):
+    if type(midifile) in (str, str):
         midifile = open(midifile, 'rb')
     reader = FileReader()
     return reader.read(midifile)

--- a/src/fileio.py
+++ b/src/fileio.py
@@ -147,13 +147,13 @@ class FileWriter:
         return ret
 
 def write_midifile(midifile, pattern):
-    if type(midifile) in (str, str):
-        midifile = open(midifile, 'wb')
+    if isinstance(midifile, str):
+        midifile = open(midifile, 'w')
     writer = FileWriter()
     return writer.write(midifile, pattern)
 
 def read_midifile(midifile):
-    if type(midifile) in (str, str):
-        midifile = open(midifile, 'rb')
+    if isinstance(midifile, str):
+        midifile = open(midifile, 'r')
     reader = FileReader()
     return reader.read(midifile)

--- a/src/sequencer.py
+++ b/src/sequencer.py
@@ -33,7 +33,7 @@ class TempoMap(list):
             last = tm
         return last
 
-class EventStreamIterator(object):
+class EventStreamIterator:
     def __init__(self, stream, window):
         self.stream = stream
         self.trackpool = stream.trackpool
@@ -50,9 +50,9 @@ class EventStreamIterator(object):
         self.ttpts.append(stream.endoftrack.tick)
         self.ttpts = iter(self.ttpts)
         # Setup next tempo timepoint
-        self.ttp = self.ttpts.next()
+        self.ttp = next(self.ttpts)
         self.tempomap = iter(self.stream.tempomap)
-        self.tempo = self.tempomap.next()
+        self.tempo = next(self.tempomap)
         self.endoftrack = False
 
     def __iter__(self):
@@ -60,14 +60,14 @@ class EventStreamIterator(object):
 
     def __next_edge(self):
         if self.endoftrack:
-            raise StopIteration
+            raise StopIteration("")
         lastedge = self.window_edge
         self.window_edge += int(self.window_length / self.tempo.mpt)
         if self.window_edge > self.ttp:
             # We're past the tempo-marker.
             oldttp = self.ttp
             try:
-                self.ttp = self.ttpts.next()
+                self.ttp = next(self.ttpts)
             except StopIteration:
                 # End of Track!
                 self.window_edge = self.ttp
@@ -77,11 +77,11 @@ class EventStreamIterator(object):
             # account the tempo change.
             msused = (oldttp - lastedge) * self.tempo.mpt
             msleft = self.window_length - msused
-            self.tempo = self.tempomap.next()
+            self.tempo = next(self.tempomap)
             ticksleft = msleft / self.tempo.mpt
             self.window_edge = ticksleft + self.tempo.tick
 
-    def next(self):
+    def __next__(self):
         ret = []
         self.__next_edge()
         if self.leftover:

--- a/src/sequencer_alsa/__init__.py
+++ b/src/sequencer_alsa/__init__.py
@@ -1,1 +1,4 @@
-from sequencer import *
+try:
+    from .sequencer import *
+except ImportError:
+    pass

--- a/src/sequencer_alsa/sequencer.py
+++ b/src/sequencer_alsa/sequencer.py
@@ -19,7 +19,7 @@ def stringify(name, obj, indent=0):
         retstr += '%s%s: %s\n' % ('    ' * indent, name, obj)
     return retstr
 
-class Sequencer(object):
+class Sequencer:
     __ARGUMENTS__ = {
         'alsa_sequencer_name':'__sequencer__',
         'alsa_sequencer_stream':S.SND_SEQ_OPEN_DUPLEX,
@@ -71,7 +71,7 @@ class Sequencer(object):
     def _error(self, errcode):
         strerr = S.snd_strerror(errcode)
         msg = "ALSAError[%d]: %s" % (errcode, strerr)
-        raise RuntimeError, msg
+        raise RuntimeError(msg)
 
     def _init_handle(self):
         ret = S.open_client(self.alsa_sequencer_name,
@@ -268,7 +268,7 @@ class Sequencer(object):
             seqev.data.control.value = event.pitch
         ## Unknown
         else:
-            print "Warning :: Unknown event type: %s" % event
+            print("Warning :: Unknown event type: %s" % event)
             return None
             
         err = S.snd_seq_event_output(self.client, seqev)
@@ -306,7 +306,7 @@ class SequencerHardware(Sequencer):
     SequencerType = "hw"
     SequencerMode = 0
 
-    class Client(object):
+    class Client:
         def __init__(self, client, name):
             self.client = client
             self.name = name
@@ -323,7 +323,7 @@ class SequencerHardware(Sequencer):
             self._ports[name] = port
 
         def __iter__(self):
-            return self._ports.itervalues()
+            return iter(self._ports.values())
 
         def __len__(self):
             return len(self._ports)
@@ -332,7 +332,7 @@ class SequencerHardware(Sequencer):
             return self._ports[key]
         __getitem__ = get_port
         
-        class Port(object):
+        class Port:
             def __init__(self, port, name, caps):
                 self.port = port
                 self.name = name
@@ -359,7 +359,7 @@ class SequencerHardware(Sequencer):
         self._query_clients()
 
     def __iter__(self):
-        return self._clients.itervalues()
+        return iter(self._clients.values())
 
     def __len__(self):
         return len(self._clients)

--- a/src/sequencer_osx/sequencer_osx.py
+++ b/src/sequencer_osx/sequencer_osx.py
@@ -31,7 +31,7 @@ def _swig_getattr(self,class_type,name):
     if (name == "thisown"): return self.this.own()
     method = class_type.__swig_getmethods__.get(name,None)
     if method: return method(self)
-    raise AttributeError,name
+    raise AttributeError(name)
 
 def _swig_repr(self):
     try: strthis = "proxy of " + self.this.__repr__()
@@ -40,7 +40,7 @@ def _swig_repr(self):
 
 import types
 try:
-    _object = types.ObjectType
+    _object = object
     _newclass = 1
 except AttributeError:
     class _object : pass

--- a/src/sequencer_osx/test.py
+++ b/src/sequencer_osx/test.py
@@ -1,9 +1,9 @@
 import sequencer_osx
-print "MIDIGetNumberOfDevices:", sequencer_osx._MIDIGetNumberOfDevices()
+print("MIDIGetNumberOfDevices:", sequencer_osx._MIDIGetNumberOfDevices())
 client = sequencer_osx._MIDIClientCreate("python")
 endpoint = sequencer_osx._MIDISourceCreate(client, "python-source")
 port = sequencer_osx._MIDIOutputPortCreate(client, "python-port")
 sequencer_osx._MIDIPortConnectSource(port, endpoint)
-print client, endpoint, endpoint
-raw_input()
+print(client, endpoint, endpoint)
+input()
 #sequencer_osx._MIDIClientDispose(handle)

--- a/src/util.py
+++ b/src/util.py
@@ -3,7 +3,7 @@ def read_varlen(data):
     NEXTBYTE = 1
     value = 0
     while NEXTBYTE:
-        chr = ord(data.next())
+        chr = ord(next(data))
         # is the hi-bit set?
         if not (chr & 0x80):
             # no next BYTE

--- a/test.py
+++ b/test.py
@@ -2,12 +2,12 @@ import midi
 import pprint
 x = midi.FileReader()
 p = midi.read('a.mid')
-print p
-raw_input()
+print(p)
+input()
 midi.write('aa.mid', p)
 p = midi.read('aa.mid')
-print p
-raw_input()
+print(p)
+input()
 #midi.write('aaa.mid', p)
 #p = midi.read('aaa.mid')
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -5,7 +5,7 @@ import mary_test
 class TestMIDI(unittest.TestCase):
     def test_varlen(self): 
         maxval = 0x0FFFFFFF
-        for inval in xrange(0, maxval, maxval / 1000):
+        for inval in range(0, maxval, maxval / 1000):
             datum = midi.write_varlen(inval)
             outval = midi.read_varlen(iter(datum))
             self.assertEqual(inval, outval)


### PR DESCRIPTION
This is related to https://github.com/aspiers/ly2video/issues/11.
It seems like the last dependency of [ly2video](https://github.com/aspiers/ly2video) that doesn't support Python 3 is python-midi.

This PR upgrades it to Python 3.

Most of the work was done by the [2to3](https://docs.python.org/3/library/2to3.html) script, with manual adjustments and updates to the shebangs.
The contents are similar to the various PRs waiting for merging in [the upstream repository](https://github.com/vishnubob/python-midi).