### PR TITLE
Fix Python 3 MIDI event parsing

### DIFF
--- a/src/events.py
+++ b/src/events.py
@@ -2,7 +2,7 @@ import pdb
 class EventRegistry:
     Events = {}
     MetaEvents = {}
-    
+
     def register_event(cls, event, bases):
         if MetaEvent in bases:
             assert event.metacommand not in cls.MetaEvents, \
@@ -22,15 +22,15 @@ EventMIDI : Concrete class used to describe MIDI Events.
 Inherits from Event.
 """
 
-class AbstractEvent:
+class EventMetaClass(type):
+    def __init__(cls, name, bases, dict):
+        if name not in ['AbstractEvent', 'Event', 'MetaEvent', 'NoteEvent']:
+            EventRegistry.register_event(cls, bases)
+
+class AbstractEvent(metaclass=EventMetaClass):
     name = "Generic MIDI Event"
     length = 0
     statusmsg = 0x0
-
-    class __metaclass__(type):
-        def __init__(cls, name, bases, dict):
-            if name not in ['AbstractEvent', 'Event', 'MetaEvent', 'NoteEvent']:
-                EventRegistry.register_event(cls, bases)
 
     def __init__(self, **kw):
         if type(self.length) == int:
@@ -65,7 +65,7 @@ MetaEvent is a special subclass of Event that is not meant to
 be used as a concrete class.  It defines a subset of Events known
 as the Meta  events.
 """
-    
+
 class Event(AbstractEvent):
     name = 'Event'
 
@@ -79,7 +79,7 @@ class Event(AbstractEvent):
     def copy(self, **kw):
         _kw = {'channel': self.channel, 'tick': self.tick, 'data': self.data}
         _kw.update(kw)
-        return self.__class__(**_kw) 
+        return self.__class__(**_kw)
 
     def __cmp__(self, other):
         if self.tick < other.tick: return -1
@@ -102,7 +102,7 @@ MetaEvent is a special subclass of Event that is not meant to
 be used as a concrete class.  It defines a subset of Events known
 as the Meta  events.
 """
-    
+
 class MetaEvent(AbstractEvent):
     statusmsg = 0xFF
     metacommand = 0x0
@@ -163,7 +163,7 @@ class ControlChangeEvent(Event):
     def get_value(self):
         return self.data[1]
     value = property(get_value, set_value)
-    
+
 class ProgramChangeEvent(Event):
     statusmsg = 0xC0
     length = 1

--- a/src/events.py
+++ b/src/events.py
@@ -22,12 +22,12 @@ EventMIDI : Concrete class used to describe MIDI Events.
 Inherits from Event.
 """
 
-class EventMetaClass(type):
+class AutoRegister(type):
     def __init__(cls, name, bases, dict):
         if name not in ['AbstractEvent', 'Event', 'MetaEvent', 'NoteEvent']:
             EventRegistry.register_event(cls, bases)
 
-class AbstractEvent(metaclass=EventMetaClass):
+class AbstractEvent(metaclass=AutoRegister):
     name = "Generic MIDI Event"
     length = 0
     statusmsg = 0x0

--- a/src/fileio.py
+++ b/src/fileio.py
@@ -57,21 +57,21 @@ class FileReader:
         # first datum is varlen representing delta-time
         tick = read_varlen(trackdata)
         # next byte is status message
-        stsmsg = ord(next(trackdata))
+        stsmsg = next(trackdata)
         # is the event a MetaEvent?
         if MetaEvent.is_event(stsmsg):
-            cmd = ord(next(trackdata))
+            cmd = next(trackdata)
             if cmd not in EventRegistry.MetaEvents:
                 raise Warning("Unknown Meta MIDI Event: " + repr(cmd))
             cls = EventRegistry.MetaEvents[cmd]
             datalen = read_varlen(trackdata)
-            data = [ord(next(trackdata)) for x in range(datalen)]
+            data = [next(trackdata) for x in range(datalen)]
             return cls(tick=tick, data=data)
         # is this event a Sysex Event?
         elif SysexEvent.is_event(stsmsg):
             data = []
             while True:
-                datum = ord(next(trackdata))
+                datum = next(trackdata)
                 if datum == 0xF7:
                     break
                 data.append(datum)
@@ -86,13 +86,13 @@ class FileReader:
                 cls = EventRegistry.Events[key]
                 channel = self.RunningStatus & 0x0F
                 data.append(stsmsg)
-                data += [ord(next(trackdata)) for x in range(cls.length - 1)]
+                data += [next(trackdata) for x in range(cls.length - 1)]
                 return cls(tick=tick, channel=channel, data=data)
             else:
                 self.RunningStatus = stsmsg
                 cls = EventRegistry.Events[key]
                 channel = self.RunningStatus & 0x0F
-                data = [ord(next(trackdata)) for x in range(cls.length)]
+                data = [next(trackdata) for x in range(cls.length)]
                 return cls(tick=tick, channel=channel, data=data)
         raise Warning("Unknown MIDI Event: " + repr(stsmsg))
 

--- a/src/fileio.py
+++ b/src/fileio.py
@@ -15,7 +15,7 @@ class FileReader:
     def parse_file_header(self, midifile):
         # First four bytes are MIDI header
         magic = midifile.read(4)
-        if magic != 'MThd':
+        if magic != b'MThd':
             raise TypeError("Bad header in MIDI file.")
         # next four bytes are header size
         # next two bytes specify the format version
@@ -36,7 +36,7 @@ class FileReader:
     def parse_track_header(self, midifile):
         # First four bytes are Track header
         magic = midifile.read(4)
-        if magic != 'MTrk':
+        if magic != b'MTrk':
             raise TypeError("Bad track header in MIDI file: " + magic)
         # next four bytes are track size
         trksz = unpack(">L", midifile.read(4))[0]

--- a/src/fileio.py
+++ b/src/fileio.py
@@ -148,12 +148,12 @@ class FileWriter:
 
 def write_midifile(midifile, pattern):
     if isinstance(midifile, str):
-        midifile = open(midifile, 'w')
+        midifile = open(midifile, 'wb')
     writer = FileWriter()
     return writer.write(midifile, pattern)
 
 def read_midifile(midifile):
     if isinstance(midifile, str):
-        midifile = open(midifile, 'r')
+        midifile = open(midifile, 'rb')
     reader = FileReader()
     return reader.read(midifile)

--- a/src/util.py
+++ b/src/util.py
@@ -3,7 +3,7 @@ def read_varlen(data):
     NEXTBYTE = 1
     value = 0
     while NEXTBYTE:
-        chr = ord(next(data))
+        chr = next(data)
         # is the hi-bit set?
         if not (chr & 0x80):
             # no next BYTE
@@ -35,4 +35,3 @@ def write_varlen(value):
     else:
         res = chr1
     return res
-


### PR DESCRIPTION
I found a few issues with #1:

* `__metaclass__` is not supported anymore in Python 3, so the MIDI meta events were not being registered, resulting in parsing errors
* When comparing the MIDI file header, we now need to compare to bytes instead of strings
* 0b57658c9050342ca313e14576eea6131f22b241 introduced a bug which I reverted (the MIDI files need to be opened in binary mode)
* 2to3 added calls to `ord()` when calling `next()`, which is not required since `next()` already returns an int in Python 3

I'm really sorry for these issues.
I can now confirm that `ly2video` works fine with Python 3 and this version of python-midi (tested under Debian Buster).

However, Python 2 is not longer supported. Is that fine in regards to `ly2video`?